### PR TITLE
Compatibility with 3.x version

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -4,7 +4,6 @@ namespace Websupport\YiiSentry;
 
 use Sentry\SentrySdk;
 use Sentry\Severity;
-use Sentry\State\Hub;
 use Sentry\State\Scope;
 use Yii;
 use CMap;

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,6 +2,7 @@
 
 namespace Websupport\YiiSentry;
 
+use Sentry\SentrySdk;
 use Sentry\Severity;
 use Sentry\State\Hub;
 use Sentry\State\Scope;
@@ -92,7 +93,7 @@ class Client extends CApplicationComponent
      */
     public function captureMessage(string $message, ?Severity $level = null, ?Scope $scope = null): ?string
     {
-        return Hub::getCurrent()->getClient()->captureMessage($message, $level, $scope);
+        return SentrySdk::getCurrentHub()->getClient()->captureMessage($message, $level, $scope);
     }
 
     /**
@@ -105,7 +106,7 @@ class Client extends CApplicationComponent
      */
     public function captureException(\Throwable $exception, ?Scope $scope = null): ?string
     {
-        return Hub::getCurrent()->getClient()->captureException($exception, $scope);
+        return SentrySdk::getCurrentHub()->getClient()->captureException($exception, $scope);
     }
 
     /**
@@ -115,7 +116,7 @@ class Client extends CApplicationComponent
      */
     public function getLastEventId()
     {
-        return Hub::getCurrent()->getLastEventId();
+        return SentrySdk::getCurrentHub()->getLastEventId();
     }
 
     /**


### PR DESCRIPTION
Hub::getCurrent() is deprecated in version 2.x and removed in 3.0.